### PR TITLE
Fix arguments to JobSpawn()

### DIFF
--- a/editorconfig-micro/editorconfig.lua
+++ b/editorconfig-micro/editorconfig.lua
@@ -148,7 +148,7 @@ function getApplyProperties(bufpane)
         log(("Running editorconfig %s"):format(fullpath))
     end
 
-    shell.JobSpawn("editorconfig", {fullpath}, nil, nil, onEditorConfigExit, buffer)
+    shell.JobSpawn("editorconfig", {fullpath}, nil, nil, editorconfig.onEditorConfigExit, buffer)
 end
 
 function onBufPaneOpen(bp)


### PR DESCRIPTION
I was getting errors related to this line when saving files. 


```
Plugin editorconfig: editorconfig:151: bad argument #3 to JobSpawn (cannot use  (type lua.LString) as type func(string, []interface {}))
stack traceback:
	[G]: in function 'JobSpawn'
	editorconfig:151: in function 'getApplyProperties'
	editorconfig:159: in main chunk
	[G]: ?
```
```
Plugin editorconfig: editorconfig:151: bad argument #5 to JobSpawn (cannot use editorconfig.onEditorConfigExit (type lua.LString) as type func(string, []interface {}))
stack traceback:
	[G]: in function 'JobSpawn'
	editorconfig:151: in function 'getApplyProperties'
	editorconfig:159: in main chunk
	[G]: ?
 ```
For the first, I changed arguments 3 and 4 `""` to `nil`.
For the second, I removed the quotes around argument 5.

Apologies in advance if this is wrong, I've never worked with Lua before.