### PR TITLE
Open in tab for filemanager plugin

### DIFF
--- a/filemanager-plugin/README.md
+++ b/filemanager-plugin/README.md
@@ -25,6 +25,7 @@ If the directory is expanded, there will be a `+` to the left of it. If it is co
 | `filemanager-compressparent` | Collapse the parent dir when left is pressed on a child file | `true`  |
 | `filemanager-foldersfirst`   | Sorts folders above any files                                | `true`  |
 | `filemanager-openonstart`    | Automatically open the file tree when starting Micro         | `false` |
+| `filemanager-openontab`      | Open the selected file in a new tab instead of a split       | `false` |
 
 ### Commands and Keybindings
 
@@ -36,6 +37,7 @@ If you want to [keybind](https://github.com/zyedidia/micro/blob/master/runtime/h
 | :------- | :------------------------- | :------------------------------------------------------------------------------------------ | :------------------------------------ |
 | `tree`   | -                          | Open/close the tree                                                                         | `filemanager.toggle_tree`             |
 | -        | <kbd>Tab</kbd> & MouseLeft | Open a file, or go into the directory. Goes back a dir if on `..`                           | `filemanager.try_open_at_cursor`      |
+| -        | <kbd>Enter</kbd>           | If `openontab` is true, open selected file in new tab                                       | `filemanager.try_open_at_cursor`      |
 | -        | <kbd>→</kbd>               | Expand directory in tree listing                                                            | `filemanager.uncompress_at_cursor`    |
 | -        | <kbd>←</kbd>               | Collapse directory listing                                                                  | `filemanager.compress_at_cursor`      |
 | -        | <kbd>Shift ⬆</kbd>         | Go to the target's parent directory                                                         | `filemanager.goto_parent_dir`         |

--- a/filemanager-plugin/filemanager.lua
+++ b/filemanager-plugin/filemanager.lua
@@ -1,4 +1,4 @@
-VERSION = "3.5.1"
+VERSION = "3.5.2"
 
 local micro = import("micro")
 local config = import("micro/config")
@@ -21,6 +21,8 @@ local current_dir = os.Getwd()
 local highest_visible_indent = 0
 -- Holds a table of paths -- objects from new_listobj() calls
 local scanlist = {}
+-- Holds the selected cursor y pos inbetween closes and opens
+local s_cursy = 2
 
 -- Get a new object used when adding to scanlist
 local function new_listobj(p, d, o, i)
@@ -525,8 +527,17 @@ local function try_open_at_y(y)
 		else
 			-- If it's a file, then open it
 			micro.InfoBar():Message("Filemanager opened ", scanlist[y].abspath)
-			-- Opens the absolute path in new vertical view
+            -- Opens the absolute path in new tab or a new split
+            if config.GetGlobalOption("filemanager.openontab") then 
+            -- CurView():VSplitIndex(NewBufferFromFile(scanlist[y].abspath), 1)
+                local nfile = scanlist[y].abspath
+                local rpath = shell.RunCommand('realpath \'' .. nfile .. '\' --relative-to=\'' .. os.Getwd() .. '\'')
+                toggle_tree()
+                micro.CurPane():NewTabCmd({string.sub(rpath, 1, -2)})
+                toggle_tree()
+            else
 			micro.CurPane():VSplitIndex(buffer.NewBufferFromFile(scanlist[y].abspath), true)
+            end
 			-- Resizes all views after opening a file
 			-- tabs[curTab + 1]:Resize()
 		end
@@ -849,12 +860,19 @@ local function open_tree()
     tree_view.Buf:SetOptionNative("scrollbar", false)
 
 	-- Fill the scanlist, and then print its contents to tree_view
+    if 0 == #scanlist then
 	update_current_dir(os.Getwd())
+    else
+        refresh_view()
+    end
+    tree_view.Cursor.Loc.Y = s_cursy
+    select_line(s_cursy)
 end
 
 -- close_tree will close the tree plugin view and release memory.
 local function close_tree()
 	if tree_view ~= nil then
+        s_cursy = tree_view.Cursor.Loc.Y
 		tree_view:Quit()
 		tree_view = nil
 		clear_messenger()
@@ -1155,6 +1173,12 @@ function preInsertTab(view)
 end
 function preInsertNewline(view)
     if view == tree_view then
+        if config.GetGlobalOption("filemanager.openontab") then
+            -- Simulate the pressing Tab so it opens with Enter key
+            tab_pressed = true
+             try_open_at_y(tree_view.Cursor.Loc.Y)
+            tab_pressed = false
+        end
         return false
     end
     return true
@@ -1352,6 +1376,9 @@ function init()
     -- Lets the user have the filetree auto-open any time Micro is opened
     -- false by default, as it's a rather noticable user-facing change
     config.RegisterCommonOption("filemanager", "openonstart", false)
+    -- Lets the user open file in new tab or in a new vsplit
+    -- false by default, as it's a rather noticable user-facing change
+    config.RegisterCommonOption("filemanager", "openontab", false)
 
     -- Open/close the tree view
     config.MakeCommand("tree", toggle_tree, config.NoComplete)

--- a/filemanager-plugin/repo.json
+++ b/filemanager-plugin/repo.json
@@ -39,6 +39,13 @@
 					"Require": {
 							"micro": ">=2.0.0-1"
 					}
+			},
+			{
+					"Version": "3.5.2",
+					"Url": "https://github.com/micro-editor/updated-plugins/releases/download/v1.0.0/filemanager-3.5.2.zip",
+					"Require": {
+							"micro": ">=2.0.0-1"
+					}
 			}
 		]
 	}


### PR DESCRIPTION
This add the configuration option for opening files in new tab instead of split (if enabled, disabled by default to avoid disruption).

When the option is true, you can also use `Enter` to open the file (in addition to `Tab`) which is a lot more intuitive. 

Fix #8