### PR TITLE
snippets: allow escaped shell vars like `${\1:?foo}`

### DIFF
--- a/micro-snippets-plugin/snippets.lua
+++ b/micro-snippets-plugin/snippets.lua
@@ -1,4 +1,4 @@
-VERSION = "0.2.0"
+VERSION = "0.2.1"
 
 local micro = import("micro")
 local buffer = import("micro/buffer")
@@ -212,6 +212,10 @@ function Snippet.Prepare(self)
 				placeHolders.value = value
 			end
 		end
+		-- allow escaped shell vars like '${\1:?foo}'
+		--   str:gsub(ptn, repl[, num])
+		local esc_ptn = "(${)\\(%d+:?[^}]*})"
+		self.code = self.code:gsub(esc_ptn, "%1%2")
 	end
 end
 


### PR DESCRIPTION
The syntax for snippet placeholders is identical to some shell parameter expansions of the positional arguments in a script. If you want to put such shell expansions in a snippet, the snippet is mangled when it's inserted.

This PR fixes the problem by allowing shell snippets to have a syntax like `${\1:?message}`, which doesn't match the pattern from snippet placeholders. After the code for identifying snippet placeholders is run, this call to `gsub` strips the backslash from the parameter expansion to produce the code that was actually intended.